### PR TITLE
Bug fix: Need Promise finish() call at end of Alamofire request callback

### DIFF
--- a/Source/DataLoader.swift
+++ b/Source/DataLoader.swift
@@ -33,6 +33,7 @@ open class DataLoader: Nuke.DataLoading {
                     } else {
                         reject(error ?? NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil))
                     }
+                    finish()
                 }
                 token?.register {
                     task.cancel()


### PR DESCRIPTION
Need to finish() at end of Alamofire manager request callback. Without this, the first set of requests succeed but eventually Promise scheduler fails to restart and everything halts.