### PR TITLE
Increase minimum deployment targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,10 +4,10 @@ import PackageDescription
 let package = Package(
     name: "Nuke Alamofire Plugin",
     platforms: [
-        .macOS(.v10_13),
-        .iOS(.v11),
-        .tvOS(.v11),
-        .watchOS(.v4)
+        .macOS(.v10_14),
+        .iOS(.v12),
+        .tvOS(.v12),
+        .watchOS(.v5)
     ],
     products: [
         .library(name: "NukeAlamofirePlugin", targets: ["NukeAlamofirePlugin"]),


### PR DESCRIPTION
Increase minimum deployment targets to iOS 12.0, watchOS 5.0, macOS 10.14, tvOS 12.0 similar to Nuke 10.10.0